### PR TITLE
Handle empty delete responses

### DIFF
--- a/netbox_react_agent/netbox_react_agent.py
+++ b/netbox_react_agent/netbox_react_agent.py
@@ -55,6 +55,8 @@ class NetBoxController:
             verify=False
         )
         response.raise_for_status()
+        if response.status_code == 204 or not response.content:
+            return {"status": "success"}
         return response.json()
 
 


### PR DESCRIPTION
## Summary
- Avoid calling `response.json()` when NetBox delete endpoint returns no content
- Return success indicator for 204 responses

## Testing
- `pytest` (no tests)


------
https://chatgpt.com/codex/tasks/task_e_68966112d254833280b8ae0305deb061