### PR TITLE
Handle empty response from NetBox delete endpoint

### DIFF
--- a/netbox_react_agent/netbox_react_agent.py
+++ b/netbox_react_agent/netbox_react_agent.py
@@ -55,7 +55,12 @@ class NetBoxController:
             verify=False
         )
         response.raise_for_status()
-        return response.json()
+        if response.content:
+            try:
+                return response.json()
+            except ValueError:
+                pass
+        return {"status": "success", "message": "Resource deleted successfully."}
 
 
 # Function to load supported URLs with their names from a JSON file


### PR DESCRIPTION
## Summary
- avoid JSON decode errors when deleting resources from NetBox

## Testing
- `python -m py_compile netbox_react_agent/netbox_react_agent.py`
- `python - <<'PY'
import ast, pathlib, requests
source = pathlib.Path('netbox_react_agent/netbox_react_agent.py').read_text()
module = ast.parse(source)
class_node = next(node for node in module.body if isinstance(node, ast.ClassDef) and node.name == 'NetBoxController')
mod = ast.Module(body=[class_node], type_ignores=[])
code = compile(mod, '<ast>', 'exec')
ns = {'requests': requests}
exec(code, ns)
NetBoxController = ns['NetBoxController']

from unittest.mock import patch, Mock
controller = NetBoxController('http://example.com', 'token')
mock_resp = Mock()
mock_resp.status_code = 204
mock_resp.content = b''
mock_resp.json.side_effect = ValueError('No JSON')
mock_resp.raise_for_status.return_value = None
with patch('requests.delete', return_value=mock_resp):
    result = controller.delete_api('/test')
print(result)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6896602d74b48332ba26870101246aed