### PR TITLE
Install langchain-openai dependency for NetBox agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN echo "==> Install dos2unix..." \
 RUN echo "==> Install requirements.." \
   && pip install --break-system-packages -U --quiet langchain_community \
   && pip install --break-system-packages streamlit --upgrade \
-  && pip install --break-system-packages openai
+  && pip install --break-system-packages openai \
+  && pip install --break-system-packages langchain-openai
 
 COPY /netbox_react_agent /netbox_react_agent/
 COPY /scripts /scripts/


### PR DESCRIPTION
## Summary
- Install `langchain-openai` in Docker image to provide `ChatOpenAI`

## Testing
- `python -m py_compile netbox_react_agent/netbox_react_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_689a4aa1b8fc833298db1e14d3c3b1ee